### PR TITLE
Point logo at portal + pin theme v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,9 @@ unified domain, while each pack deploys and previews independently.
    not already there. The dashboard schema is at
    `nebari-dev/software-pack-dashboard/schema/pack-metadata.schema.json`.
 
+4. **Set `params.logoLink = "https://packs.nebari.dev/"` in `hugo.toml`** so the header
+   logo returns to the portal.
+
 ### How it works
 
 - **Production:** push to `main` builds Hugo with `baseURL https://packs.nebari.dev/<slug>/`

--- a/docs/site/go.mod
+++ b/docs/site/go.mod
@@ -2,4 +2,4 @@ module github.com/nebari-dev/nebari-software-pack-template/docs/site
 
 go 1.26.3
 
-require github.com/nebari-dev/nebari-hugo-theme v0.1.1 // indirect
+require github.com/nebari-dev/nebari-hugo-theme v0.2.0 // indirect

--- a/docs/site/go.sum
+++ b/docs/site/go.sum
@@ -4,3 +4,5 @@ github.com/nebari-dev/nebari-hugo-theme v0.1.0 h1:xfzAx5ZEjjn5jrxKox8FtmnaDaBGi8
 github.com/nebari-dev/nebari-hugo-theme v0.1.0/go.mod h1:N0PJCjHPJ69fOjfhNfaZsXcr+0CryBTJ7xEx7pmARSk=
 github.com/nebari-dev/nebari-hugo-theme v0.1.1 h1:yhWGv1J1ipsGW9jZRKo/J7cN84neh4w+jIwBe6mAmXc=
 github.com/nebari-dev/nebari-hugo-theme v0.1.1/go.mod h1:N0PJCjHPJ69fOjfhNfaZsXcr+0CryBTJ7xEx7pmARSk=
+github.com/nebari-dev/nebari-hugo-theme v0.2.0 h1:OsqVFwvwhmjJCtLe60OIk4lPZb1OUviHHvb4nozWlxE=
+github.com/nebari-dev/nebari-hugo-theme v0.2.0/go.mod h1:N0PJCjHPJ69fOjfhNfaZsXcr+0CryBTJ7xEx7pmARSk=

--- a/docs/site/hugo.toml
+++ b/docs/site/hugo.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "Building a Software Pack"
 enableGitInfo = true
 
-# Theme imported as a Hugo Module, pinned to a release tag in go.mod (currently v0.1.1).
+# Theme imported as a Hugo Module, pinned to a release tag in go.mod (currently v0.2.0).
 [module]
   [[module.imports]]
     path = "github.com/nebari-dev/nebari-hugo-theme"
@@ -23,6 +23,7 @@ enableGitInfo = true
   home = ["HTML", "RSS", "JSON"]
 
 [params]
+  logoLink = "https://packs.nebari.dev/"
   description = "A deep-dive guide to building, deploying, and maintaining Nebari Software Packs - Kubernetes applications with routing, TLS, and OIDC wired in."
   repo = "https://github.com/nebari-dev/nebari-software-pack-template"
   editBase = "https://github.com/nebari-dev/nebari-software-pack-template/edit/main/docs/site/content"


### PR DESCRIPTION
## Summary

- Bumps `nebari-hugo-theme` pin from v0.1.1 to v0.2.0 in `docs/site/go.mod` + `go.sum`
- Adds `params.logoLink = "https://packs.nebari.dev/"` as the first key under `[params]` in `docs/site/hugo.toml`, so the header logo navigates back to the portal root instead of the pack's own home
- Documents the `logoLink` param in `README.md` under the docs-portal Opting in steps (new step 4)

## Test plan

- [x] `hugo mod get github.com/nebari-dev/nebari-hugo-theme@v0.2.0` resolved cleanly
- [x] `hugo --gc --minify --baseURL "https://packs.nebari.dev/building-a-software-pack/"` succeeded (15 pages, 97 ms)
- [x] `grep 'site-header__brand' public/index.html` confirmed `href="https://packs.nebari.dev/"` in the rendered output