### PR TITLE
ci: fix docs preview-cleanup (HTTP 400) and move CI off Node 20

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -30,8 +30,20 @@ jobs:
         run: |
           set -euo pipefail
           base="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${CF_PROJECT}/deployments"
-          ids=$(curl -fsS -H "Authorization: Bearer ${CF_API_TOKEN}" "${base}?env=preview&per_page=100" \
-            | jq -r --arg b "$BRANCH" '.result[] | select(.deployment_trigger.metadata.branch == $b) | .id')
+          # Collect this branch's preview deployment ids. Page through results:
+          # the endpoint rejects an oversized per_page with HTTP 400, so use the
+          # default page size and paginate until a page comes back empty.
+          ids=""
+          page=1
+          while :; do
+            resp=$(curl -fsS -H "Authorization: Bearer ${CF_API_TOKEN}" "${base}?env=preview&page=${page}")
+            count=$(printf '%s' "$resp" | jq '.result | length')
+            [ "$count" -eq 0 ] && break
+            match=$(printf '%s' "$resp" | jq -r --arg b "$BRANCH" '.result[] | select(.deployment_trigger.metadata.branch == $b) | .id')
+            [ -n "$match" ] && ids="${ids}${match}"$'\n'
+            page=$((page + 1))
+            [ "$page" -gt 100 ] && break
+          done
           if [ -z "$ids" ]; then
             echo "No preview deployments found for branch '$BRANCH'."
             exit 0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Install kubeconform
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Update dependencies
         run: helm dependency update ${{ inputs.chart_path }} || true

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -19,10 +19,10 @@ jobs:
       OPERATOR_REF: v0.1.0-alpha.19
     steps:
       - name: Checkout software-pack-template
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout nebari-operator (for dev/scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: nebari-dev/nebari-operator
           ref: ${{ env.OPERATOR_REF }}
@@ -34,7 +34,7 @@ jobs:
           cluster_name: pack-integration
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       # ============================================================
       # Infrastructure: MetalLB

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create kind cluster
         uses: helm/kind-action@v1
@@ -18,7 +18,7 @@ jobs:
           cluster_name: pack-test
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       # Test vanilla YAML example
       - name: Apply vanilla-yaml manifests


### PR DESCRIPTION
## What

Two CI fixes:

### 1. Fix the failing "Docs preview cleanup" workflow
The `cleanup` job listed Cloudflare Pages deployments with `per_page=100`, which the deployments endpoint rejects with **HTTP 400** (`curl -fsS` -> exit 22). This is why the workflow failed on PR #16's own close event (the "Delete this branch's preview deployments" step).

Fix: page through deployments with the endpoint's default page size (`?env=preview&page=N`, looping until an empty page), collecting this branch's deployment ids. `env` was fine; only the oversized `per_page` was the problem. Verified the parameter contract against Cloudflare's [list-deployments API docs](https://developers.cloudflare.com/api/resources/pages/subresources/projects/subresources/deployments/methods/list/).

### 2. Move CI off the deprecated Node 20 runtime
Bumped `actions/checkout@v4 -> v5` and `azure/setup-helm@v4 -> v5` across `build-image`, `lint`, `release`, `test`, and `test-integration`. `azure/setup-helm@v5`'s headline change is the node20 -> node24 runtime move with no input changes, and all usages are bare (no pinned inputs), so this is a safe bump.

`docs.yml` is intentionally left untouched: the Astro/Starlight migration PR (#18) replaces that workflow wholesale and already uses `checkout@v5`, so editing it here would collide.

## Testing
- All workflows parse (`yaml.safe_load`) and are `actionlint`-clean (shellcheck validated the cleanup script).
- The cleanup fix's live path needs the Cloudflare secrets + a real PR-close event, so it is exercised the next time a docs PR closes. The query contract and shell are validated as above.