### PR TITLE
ci: move remaining actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -10,8 +10,8 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      # https://github.com/actions/add-to-project/releases/tag/v1.0.2
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
+      # https://github.com/actions/add-to-project/releases/tag/v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd
         with:
           project-url: ${{ vars.PROJECT_BOARD_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -21,14 +21,14 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: examples/auth-fastapi
           push: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Deploy to Cloudflare Pages
         id: deploy
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Why

GitHub is deprecating the `node20` action runtime. This audits every `uses:` reference across all workflows and moves the ones still on `node20` to versions that run on `node24`.

## Audit

I read the `action.yml` `runs.using` field for every pinned action:

| Action | Was | Runtime before | Now | Runtime after |
|---|---|---|---|---|
| `actions/add-to-project` | `244f685` (v1.0.2) | node20 | `5afcf98` (v2.0.0) | **node24** |
| `docker/login-action` | `v3` | node20 | `v4` | **node24** |
| `docker/build-push-action` | `v6` | node20 | `v7` | **node24** |
| `cloudflare/wrangler-action` | `v3` | node20 | `v4` | **node24** |
| `thollander/actions-comment-pull-request` | `v3` | node20 | `v3` (unchanged) | node20 |
| `actions/checkout` | `v5` | node24 | - | already fine |
| `azure/setup-helm` | `v5` | node24 | - | already fine |
| `helm/kind-action` | `v1` | node24 | - | already fine |
| `oven-sh/setup-bun` | `v2` | node24 | - | already fine |

`thollander/actions-comment-pull-request` stays on `v3`: its latest release and its default branch both still target `node20`, so there is no `node24` version to move to yet. Worth a follow-up once upstream migrates.

## Breaking-change review (all four are major bumps)

- **add-to-project v1.0.2 → v2.0.0**: release is dependency/runtime updates; `project-url` and `github-token` inputs unchanged. Kept SHA-pinned (verified `5afcf98` is the v2.0.0 commit).
- **wrangler-action v3 → v4**: only documented major change is the default Wrangler version becoming v4. Our step uses `apiToken`/`accountId`/`command: pages deploy ...`, all unchanged in v4.
- **build-push-action v6 → v7**: node24 default (needs Actions Runner ≥ v2.327.1, which `ubuntu-latest` exceeds); removes the deprecated `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs, neither of which we set. `context`/`push`/`tags` unchanged.
- **login-action v3 → v4**: node24 default + internal ESM switch; `registry`/`username`/`password` inputs unchanged.

## Verification

- Re-audited all pinned refs after the edits: the four upgraded actions now report `using: node24`.
- All 8 workflow files parse as valid YAML.
- Opening this PR exercises `wrangler-action@v4` (the `docs` job, since this touches `docs.yml`) and `add-to-project@v2` (runs on PR opened) live.
- `build-image.yaml` only runs on pushes to `examples/auth-fastapi/**`, so the two docker bumps are not exercised by this PR; they're covered by the input/env/runner review above. Happy to `workflow_dispatch` it after merge to confirm the image build.
